### PR TITLE
Update is-a.dev API link

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -175,7 +175,7 @@ const Home = () => {
   useEffect(() => {    
     const fetchData = async () => {
       try {
-        const response = await fetch('https://raw-api.is-a.dev/');
+        const response = await fetch('https://raw.is-a.dev/');
         const data = await response.json();
         
         const processedItems = data.map((item, index) => {


### PR DESCRIPTION
Site is screwed atm because `https://raw-api.is-a.dev` redirects to `https://raw.is-a.dev`.

Not sure if I also had to modify somewhere else but oh well.